### PR TITLE
Update super-linter workflow to skip dependabot

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -18,6 +18,7 @@ jobs:
       statuses: write # for github/super-linter/slim to mark status of each linter run
     name: Lint Code Base
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
 
     steps:
       - name: Checkout Code
@@ -25,6 +26,9 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Install dependencies
+        run: npm i
 
       - name: Lint Code Base
         uses: super-linter/super-linter/slim@61abc07d755095a68f4987d1c2c3d1d64408f1f9 # v8.5.0


### PR DESCRIPTION
Added condition to skip linting for dependabot commits and included a step to install dependencies.
